### PR TITLE
Draw nodes with at least `l` edges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [vimwiki](https://github.com/vimwiki/vimwiki) directory and builds a
 graph between the encountered files and their internal references. The
 code supports vimwiki-style links `[[link]]`, `[[link|description]]`
-and markdown-style links `(description)[link]`. The graph is 
+and markdown-style links `(description)[link]`. The graph is
 converted to the DOT language
 using [`dot`](https://github.com/emicklei/dot). The results can then be
 visualised with [graphviz](https://www.graphviz.org/about/), e.g. using
@@ -19,6 +19,11 @@ providing new insights.
 `-diary`: collapse all diary entries under a single node `diary.wiki`
 
 `-cluster`: cluster subdirectories as subgraphs
+
+`-l`: only nodes with at least `l` edges are inserted. The inserted nodes are
+inserted with all their edges. Thus, nodes with less than `l` edges can appear
+when they are connected to other nodes that do satisfy the requirement.
+For `-l 0`, all nodes are inserted.
 
 ## Examples
 To illustrate `/example/` contains some `.wiki` files and also a

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 
 	cluster := flag.Bool("cluster", false, "cluster nodes in sub directories")
 	diary := flag.Bool("diary", false, "collapse all diary entries under a single `diary.wiki` node")
+	level := flag.Int("l", 1, "draw only edges from nodes with at least level number of edges")
 	flag.Parse()
 
 	// remap any path that contains `diary` into `diary.wiki`
@@ -49,7 +50,7 @@ func main() {
 	}
 
 	// convert to a dot-graph for visualisation
-	g := wiki.Dot(dot.Directed)
+	g := wiki.Dot(*level, dot.Directed)
 	g.Attr("rankdir", "LR")
 	g.Write(os.Stdout)
 }

--- a/vimwikigraph.go
+++ b/vimwikigraph.go
@@ -210,10 +210,14 @@ func (wiki *Wiki) Add(path string) error {
 
 // Dot converts wiki.graph into dot.Graph.
 //
+// Only nodes, and their connections, are drawn if their sum of edges
+// is greater than the provided level. For `level = 0` all nodes
+// are inserted.
+//
 // If wiki.cluster == true any nodes that correspond to a subdirectory are
 // inserted in the corresponding subgraph of that subdirectory. By default, the
 // visualisation will highlight these subgraphs.
-func (wiki *Wiki) Dot(opts ...dot.GraphOption) *dot.Graph {
+func (wiki *Wiki) Dot(level int, opts ...dot.GraphOption) *dot.Graph {
 	graph := dot.NewGraph()
 	for _, opt := range opts {
 		opt.Apply(graph)
@@ -223,8 +227,8 @@ func (wiki *Wiki) Dot(opts ...dot.GraphOption) *dot.Graph {
 
 	for k, val := range wiki.graph {
 
-		// only draw nodes with connection
-		if len(val) == 0 {
+		// skip nodes with less edges
+		if len(val) < level {
 			continue
 		}
 


### PR DESCRIPTION
Adds the option `-l` to indicate the minimum number of edges a nodes is
required to have before being inserted into the graph. Nodes having at
least `l` edges, are inserted in the graph, including all their
connections.

By providing `-l 0` all nodes, including single nodes without any
inbound or outbound edges, will be drawn.

Closes #4.