### PR TITLE
README: Fix Markdown link example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [vimwiki](https://github.com/vimwiki/vimwiki) directory and builds a
 graph between the encountered files and their internal references. The
 code supports vimwiki-style links `[[link]]`, `[[link|description]]`
-and markdown-style links `(description)[link]`. The graph is
+and markdown-style links `[description](link)`. The graph is
 converted to the DOT language
 using [`dot`](https://github.com/emicklei/dot). The results can then be
 visualised with [graphviz](https://www.graphviz.org/about/), e.g. using


### PR DESCRIPTION
- Thanks for building this tool! I'm about to try it out, but in reading about it I noticed this typo. :-)